### PR TITLE
Add NestedLoopJoin Operator

### DIFF
--- a/src/main/scala/de/hpi/svedeb/operators/NestedLoopJoinOperator.scala
+++ b/src/main/scala/de/hpi/svedeb/operators/NestedLoopJoinOperator.scala
@@ -67,6 +67,7 @@ class NestedLoopJoinOperator(leftTable: ActorRef,
   override def receive: Receive = active(JoinState(ActorRef.noSender, None, None, None, None, Map.empty))
 
   def initializeJoin(state: JoinState): Unit = {
+    log.debug("Initialize Join")
     leftTable ! GetPartitions()
     rightTable ! GetPartitions()
     leftTable ! ListColumnsInTable()
@@ -75,6 +76,7 @@ class NestedLoopJoinOperator(leftTable: ActorRef,
   }
 
   def handlePartitions(state: JoinState, partitions: Seq[ActorRef]): Unit = {
+    log.debug(s"Handle partitions $partitions")
     val newState = state.storePartitions(sender(), leftTable, rightTable, partitions)
     context.become(active(newState))
 
@@ -97,6 +99,7 @@ class NestedLoopJoinOperator(leftTable: ActorRef,
   }
 
   def handleColumnNames(state: JoinState, columnNames: Seq[String]): Unit = {
+    log.debug(s"Handle column names $columnNames")
     val newState = state.storeColumnNames(sender(), leftTable, rightTable, columnNames)
     context.become(active(newState))
 
@@ -106,6 +109,7 @@ class NestedLoopJoinOperator(leftTable: ActorRef,
   }
 
   def handlePartialResult(state: JoinState, partitionId: Int, partition: Option[ActorRef]): Unit = {
+    log.debug(s"Handle partial result for $partitionId with $partition")
     val newState = state.storePartialResult(partitionId, partition)
     context.become(active(newState))
 
@@ -115,6 +119,7 @@ class NestedLoopJoinOperator(leftTable: ActorRef,
   }
 
   private def createNewTable(state: JoinState): Unit = {
+    log.debug("Create new table")
     val table = context.actorOf(Table.props(
       state.leftColumnNames.get ++ state.rightColumnNames.get,
       Utils.defaultPartitionSize,

--- a/src/main/scala/de/hpi/svedeb/operators/NestedLoopJoinOperator.scala
+++ b/src/main/scala/de/hpi/svedeb/operators/NestedLoopJoinOperator.scala
@@ -1,40 +1,128 @@
 package de.hpi.svedeb.operators
 
 import akka.actor.{ActorRef, Props}
-import de.hpi.svedeb.operators.AbstractOperator.Execute
+import de.hpi.svedeb.operators.AbstractOperator.{Execute, QueryResult}
 import de.hpi.svedeb.operators.NestedLoopJoinOperator.JoinState
-import de.hpi.svedeb.operators.workers.NestedLoopJoinWorker.PartialResult
-import de.hpi.svedeb.table.Table.PartitionsInTable
+import de.hpi.svedeb.operators.ScanOperator.ScanState
+import de.hpi.svedeb.operators.workers.NestedLoopJoinWorker
+import de.hpi.svedeb.operators.workers.NestedLoopJoinWorker.{JoinJob, PartialResult}
+import de.hpi.svedeb.table.Table
+import de.hpi.svedeb.table.Table.{ColumnList, GetPartitions, ListColumnsInTable, PartitionsInTable}
+import de.hpi.svedeb.utils.Utils
 
 object NestedLoopJoinOperator {
-  def props(leftTable: ActorRef, rightTable: ActorRef): Props = Props(new NestedLoopJoinOperator(leftTable, rightTable))
+  def props(leftTable: ActorRef, rightTable: ActorRef, leftJoinColumn: String,
+            rightJoinColumn: String,
+            predicate: (String, String) => Boolean): Props = Props(new NestedLoopJoinOperator(leftTable, rightTable, leftJoinColumn, rightJoinColumn, predicate))
 
-  private case class JoinState(originalSender: ActorRef)
+  private case class JoinState(originalSender: ActorRef,
+                               leftPartitions: Option[Seq[ActorRef]],
+                               rightPartitions: Option[Seq[ActorRef]],
+                               leftColumnNames: Option[Seq[String]],
+                               rightColumnNames: Option[Seq[String]],
+                               result: Map[Int, Option[ActorRef]]) {
+    def storeSender(sender: ActorRef): JoinState = {
+      JoinState(sender, leftPartitions, rightPartitions, leftColumnNames, rightColumnNames, result)
+    }
+
+    def storePartitions(sender: ActorRef, leftTable: ActorRef, rightTable: ActorRef, partitions: Seq[ActorRef]): JoinState = {
+      if (sender == leftTable) {
+        JoinState(originalSender, Some(partitions), rightPartitions, leftColumnNames, rightColumnNames, result)
+      } else if (sender == rightTable) {
+        JoinState(originalSender, leftPartitions, Some(partitions), leftColumnNames, rightColumnNames, result)
+      } else {
+        throw new Exception(s"Unexpected sender $sender")
+      }
+    }
+
+    def storePartialResult(partitionId: Int, partition: Option[ActorRef]): JoinState = {
+      JoinState(originalSender, leftPartitions, rightPartitions, leftColumnNames, rightColumnNames, result + (partitionId -> partition))
+    }
+
+    def storeColumnNames(sender: ActorRef, leftTable: ActorRef, rightTable: ActorRef, columnNames: Seq[String]): JoinState = {
+      if (sender == leftTable) {
+        JoinState(originalSender, leftPartitions, rightPartitions, Some(columnNames), rightColumnNames, result)
+      } else if (sender == rightTable) {
+        JoinState(originalSender, leftPartitions, rightPartitions, leftColumnNames, Some(columnNames), result)
+      } else {
+        throw new Exception(s"Unexpected sender $sender")
+      }
+    }
+
+    def hasFinished: Boolean = {
+      leftPartitions.isDefined &&
+        rightPartitions.isDefined &&
+        result.size == leftPartitions.get.size * rightPartitions.get.size &&
+        leftColumnNames.isDefined &&
+        rightColumnNames.isDefined
+    }
+  }
 }
 
-class NestedLoopJoinOperator(leftTable: ActorRef, rightTable: ActorRef) extends AbstractOperator {
-  override def receive: Receive = active(JoinState(ActorRef.noSender))
+class NestedLoopJoinOperator(leftTable: ActorRef,
+                             rightTable: ActorRef,
+                             leftJoinColumn: String,
+                             rightJoinColumn: String,
+                             predicate: (String, String) => Boolean) extends AbstractOperator {
+  override def receive: Receive = active(JoinState(ActorRef.noSender, None, None, None, None, Map.empty))
 
-  def initializeJoin(): Unit = {
-    // fetch partitions
-    context.become(active(JoinState(sender())))
+  def initializeJoin(state: JoinState): Unit = {
+    leftTable ! GetPartitions()
+    rightTable ! GetPartitions()
+    leftTable ! ListColumnsInTable()
+    rightTable ! ListColumnsInTable()
+    context.become(active(state.storeSender(sender())))
   }
 
-  def handlePartitions(partitions: Seq[ActorRef]): Unit = {
+  def handlePartitions(state: JoinState, partitions: Seq[ActorRef]): Unit = {
     // save once with sender
-    // invoke join jobs else
-    // save number of jobs, forward partition id
+    val newState = state.storePartitions(sender(), leftTable, rightTable, partitions)
+    context.become(active(newState))
+
+    if (newState.leftPartitions.isDefined && newState.rightPartitions.isDefined) {
+      val rightPartitionSize = newState.rightPartitions.get.size
+      newState.leftPartitions.get.zipWithIndex.foreach{
+        case (leftPartition, leftIndex) => newState.rightPartitions.get.zipWithIndex.foreach{
+          case (rightPartition, rightIndex) =>
+            val newPartitionId = leftIndex * rightPartitionSize + rightIndex
+            val worker = context.actorOf(NestedLoopJoinWorker.props(leftPartition, rightPartition, newPartitionId, leftJoinColumn, rightJoinColumn, predicate))
+            worker ! JoinJob()
+      }}
+    }
   }
 
-  def handlePartialResult(partitionId: Int, partition: Option[ActorRef]): Unit = {
-    // store result
-    // if all received, create new table and return
+  def handleColumnNames(state: JoinState, columnNames: Seq[String]): Unit = {
+    val newState = state.storeColumnNames(sender(), leftTable, rightTable, columnNames)
+    context.become(active(newState))
+
+    if (newState.hasFinished) {
+      createNewTable(newState)
+    }
+  }
+
+  def handlePartialResult(state: JoinState, partitionId: Int, partition: Option[ActorRef]): Unit = {
+    val newState = state.storePartialResult(partitionId, partition)
+    context.become(active(newState))
+
+    if (newState.hasFinished) {
+      createNewTable(newState)
+    }
+  }
+
+  private def createNewTable(state: JoinState): Unit = {
+    val table = context.actorOf(Table.props(
+      state.leftColumnNames.get ++ state.rightColumnNames.get,
+      Utils.defaultPartitionSize,
+      state.result.toSeq.sortBy(_._1).flatMap(_._2)))
+    log.debug("Created output table, sending to {}", state.originalSender)
+    state.originalSender ! QueryResult(table)
   }
 
   private def active(state: JoinState): Receive = {
-    case Execute() => initializeJoin()
-    case PartitionsInTable(partitions) => handlePartitions(partitions)  // get partitions
-    case PartialResult(partitionId, partition) => handlePartialResult(partitionId, partition)
+    case Execute() => initializeJoin(state)
+    case PartitionsInTable(partitions) => handlePartitions(state, partitions)  // get partitions
+    case ColumnList(columnNames) => handleColumnNames(state, columnNames)
+    case PartialResult(partitionId, partition) => handlePartialResult(state, partitionId, partition)
     case m => throw new Exception(s"Message not understood: $m")
   }
 }

--- a/src/main/scala/de/hpi/svedeb/operators/NestedLoopJoinOperator.scala
+++ b/src/main/scala/de/hpi/svedeb/operators/NestedLoopJoinOperator.scala
@@ -1,0 +1,43 @@
+package de.hpi.svedeb.operators
+
+import akka.actor.{ActorRef, Props}
+import de.hpi.svedeb.operators.AbstractOperator.Execute
+import de.hpi.svedeb.operators.NestedLoopJoinOperator.JoinState
+import de.hpi.svedeb.operators.workers.ScanWorker.{ScanJob, State}
+import de.hpi.svedeb.table.Column.{FilteredRowIndices, ScannedValues}
+import de.hpi.svedeb.table.Partition.ColumnsRetrieved
+import de.hpi.svedeb.table.Table.PartitionsInTable
+
+object NestedLoopJoinOperator {
+  def props(leftTable: ActorRef, rightTable: ActorRef): Props = Props(new NestedLoopJoinOperator(leftTable, rightTable))
+
+  private case class JoinState(originalSender: ActorRef)
+}
+
+class NestedLoopJoinOperator(leftTable: ActorRef, rightTable: ActorRef) extends AbstractOperator {
+  override def receive: Receive = active(JoinState(ActorRef.noSender))
+
+  def initializeJoin(): Unit = {
+    // fetch partitions
+    context.become(active(JoinState(sender())))
+  }
+
+  def handlePartitions(partitions: Seq[ActorRef]): Unit = {
+    // save once with sender
+    // invoke join jobs else
+    // save number of jobs, forward partition id
+  }
+
+  def handlePartialResult(partitionId: Int, partition: ActorRef): Unit = {
+    // store result
+    // if all received, create new table and return
+  }
+
+  private def active(state: JoinState): Receive = {
+    case Execute() => initializeJoin()
+    case PartitionsInTable(partitions) => handlePartitions(partitions)  // get partitions
+    case PartialResult(partitionId, partition) => handlePartialResult(partitionId, partition)
+    case m => throw new Exception(s"Message not understood: $m")
+  }
+}
+

--- a/src/main/scala/de/hpi/svedeb/operators/NestedLoopJoinOperator.scala
+++ b/src/main/scala/de/hpi/svedeb/operators/NestedLoopJoinOperator.scala
@@ -3,9 +3,7 @@ package de.hpi.svedeb.operators
 import akka.actor.{ActorRef, Props}
 import de.hpi.svedeb.operators.AbstractOperator.Execute
 import de.hpi.svedeb.operators.NestedLoopJoinOperator.JoinState
-import de.hpi.svedeb.operators.workers.ScanWorker.{ScanJob, State}
-import de.hpi.svedeb.table.Column.{FilteredRowIndices, ScannedValues}
-import de.hpi.svedeb.table.Partition.ColumnsRetrieved
+import de.hpi.svedeb.operators.workers.NestedLoopJoinWorker.PartialResult
 import de.hpi.svedeb.table.Table.PartitionsInTable
 
 object NestedLoopJoinOperator {
@@ -28,7 +26,7 @@ class NestedLoopJoinOperator(leftTable: ActorRef, rightTable: ActorRef) extends 
     // save number of jobs, forward partition id
   }
 
-  def handlePartialResult(partitionId: Int, partition: ActorRef): Unit = {
+  def handlePartialResult(partitionId: Int, partition: Option[ActorRef]): Unit = {
     // store result
     // if all received, create new table and return
   }

--- a/src/main/scala/de/hpi/svedeb/operators/workers/NestedLoopJoinWorker.scala
+++ b/src/main/scala/de/hpi/svedeb/operators/workers/NestedLoopJoinWorker.scala
@@ -89,8 +89,10 @@ class NestedLoopJoinWorker(leftPartition: ActorRef,
     context.become(active(newState))
 
     if(newState.leftColumnRefs.isDefined && newState.rightColumnRefs.isDefined) {
-      newState.leftColumnRefs.get.apply(leftJoinColumn) ! ScanColumn(None)
-      newState.rightColumnRefs.get.apply(rightJoinColumn) ! ScanColumn(None)
+      val leftColumn = newState.leftColumnRefs.get.apply(leftJoinColumn)
+      leftColumn ! ScanColumn(None)
+      val rightColumn = newState.rightColumnRefs.get.apply(rightJoinColumn)
+      rightColumn ! ScanColumn(None)
     }
   }
 

--- a/src/main/scala/de/hpi/svedeb/operators/workers/NestedLoopJoinWorker.scala
+++ b/src/main/scala/de/hpi/svedeb/operators/workers/NestedLoopJoinWorker.scala
@@ -1,0 +1,123 @@
+package de.hpi.svedeb.operators.workers
+
+import akka.actor.{Actor, ActorLogging, ActorRef}
+import de.hpi.svedeb.operators.workers.NestedLoopJoinWorker.{JoinJob, JoinWorkerState, PartialResult}
+import de.hpi.svedeb.table.Column.{ScanColumn, ScannedValues}
+import de.hpi.svedeb.table.{ColumnType, Partition}
+import de.hpi.svedeb.table.Partition.{ColumnsRetrieved, GetColumns}
+import de.hpi.svedeb.utils.Utils
+
+object NestedLoopJoinWorker {
+  case class JoinJob()
+  case class PartialResult(partitionId: Int, partition: Option[ActorRef])
+
+  // TODO: columns could have same name -- rename?
+  private case class JoinWorkerState(sender: Option[ActorRef],
+                                     leftColumnRefs: Option[Map[String, ActorRef]],
+                                     rightColumnRefs: Option[Map[String, ActorRef]],
+                                     leftColumnValues: Option[ColumnType],
+                                     rightColumnValues: Option[ColumnType],
+                                     postJoin: Boolean = false,
+                                     result: Map[String, ColumnType] = Map.empty[String, ColumnType]) {
+    def addResultForColumn(columnName: String, values: ColumnType): JoinWorkerState = {
+      val newResultMap = result + (columnName -> values)
+      JoinWorkerState(sender, leftColumnRefs, rightColumnRefs, leftColumnValues, rightColumnValues, postJoin, newResultMap)
+    }
+
+    def storeSender(sender: ActorRef): JoinWorkerState = {
+      JoinWorkerState(Some(sender), leftColumnRefs, rightColumnRefs, leftColumnValues, rightColumnValues, postJoin, result)
+    }
+
+    def saveColumnRefs(partition: ActorRef, leftPartition: ActorRef, rightPartition: ActorRef, columns: Map[String, ActorRef]): JoinWorkerState = {
+      if (partition == leftPartition) JoinWorkerState(sender, Some(columns), rightColumnRefs, leftColumnValues, rightColumnValues, postJoin, result)
+      else JoinWorkerState(sender, leftColumnRefs, Some(columns), leftColumnValues, rightColumnValues, postJoin, result)
+    }
+
+    def saveColumnValues(partition: ActorRef, leftPartition: ActorRef, rightPartition: ActorRef, column: ColumnType): JoinWorkerState = {
+      if (partition == leftPartition) JoinWorkerState(sender, leftColumnRefs, rightColumnRefs, Some(column), rightColumnValues, postJoin, result)
+      else JoinWorkerState(sender, leftColumnRefs, rightColumnRefs, leftColumnValues, Some(column), postJoin, result)
+    }
+
+    def enterPostJoin(): JoinWorkerState = {
+      JoinWorkerState(sender, leftColumnRefs, rightColumnRefs, leftColumnValues, rightColumnValues, postJoin = true, result)
+    }
+  }
+}
+
+class NestedLoopJoinWorker(leftPartition: ActorRef,
+                           rightPartition: ActorRef,
+                           resultPartitionId: Int,
+                           leftJoinColumn: String,
+                           rightJoinColumn: String) extends Actor with ActorLogging {
+  override def receive: Receive = active(JoinWorkerState(None, None, None, None, None))
+
+  private def beginJoinJob(state: JoinWorkerState): Unit = {
+    val newState = state.storeSender(sender())
+    context.become(active(newState))
+
+    leftPartition ! GetColumns()
+    rightPartition ! GetColumns()
+  }
+
+  def handleColumnsRetrieved(state: JoinWorkerState, columns: Map[String, ActorRef]): Unit = {
+    val newState = state.saveColumnRefs(sender(), leftPartition, rightPartition, columns)
+    context.become(active(newState))
+
+    if(newState.leftColumnRefs.isDefined && newState.rightColumnRefs.isDefined) {
+      newState.leftColumnRefs.get.apply(leftJoinColumn) ! ScanColumn(None)
+      newState.rightColumnRefs.get.apply(rightJoinColumn) ! ScanColumn(None)
+    }
+  }
+
+  def handleScannedValues(state: JoinWorkerState, columnName: String, values: ColumnType): Unit = {
+    if (state.postJoin) {
+      storeResult(state, columnName, values)
+    } else {
+      handleJoinInput(state, values)
+    }
+  }
+
+  private def storeResult(state: JoinWorkerState, columnName: String, values: ColumnType): Unit = {
+    val newState = state.addResultForColumn(columnName, values)
+    context.become(active(newState))
+
+    if (newState.leftColumnRefs.get.size + newState.rightColumnRefs.get.size == newState.result.size) {
+      if (newState.result.forall(_._2.values.isEmpty)) {
+        newState.sender.get ! PartialResult(resultPartitionId, None)
+      } else {
+        val newPartition = context.actorOf(Partition.props(resultPartitionId, newState.result, Utils.defaultPartitionSize))
+        newState.sender.get ! PartialResult(resultPartitionId, Some(newPartition))
+      }
+    }
+  }
+
+  private def handleJoinInput(state: JoinWorkerState, values: ColumnType): Unit = {
+    val newState = state.saveColumnValues(sender(), leftPartition, rightPartition, values)
+    context.become(active(newState))
+
+    if (newState.leftColumnValues.isDefined && newState.rightColumnValues.isDefined) {
+      val indexedLeft = newState.leftColumnValues.get.values.zipWithIndex
+      val indexedRight = newState.rightColumnValues.get.values.zipWithIndex
+
+      val joinedIndices = indexedLeft.flatMap { case (leftValue, leftIndex) =>
+        indexedRight.flatMap { case (rightValue, rightIndex) =>
+          if (leftValue == rightValue) Some(leftIndex, rightIndex)
+          else None
+        }
+      }
+
+      newState.leftColumnRefs.get.foreach { case (_, column) => column ! ScanColumn(Some(joinedIndices.map(_._1))) }
+      newState.rightColumnRefs.get.foreach { case (_, column) => column ! ScanColumn(Some(joinedIndices.map(_._2))) }
+
+      val postJoinState = state.enterPostJoin()
+      context.become(active(postJoinState))
+    }
+  }
+
+  def active(state: JoinWorkerState): Receive = {
+    case JoinJob() => beginJoinJob(state)
+    case ColumnsRetrieved(columns) => handleColumnsRetrieved(state, columns)
+    case ScannedValues(partitionId, columnName, values) => handleScannedValues(state, columnName, values)
+    case m => throw new Exception(s"Message not understood: $m")
+  }
+}

--- a/src/main/scala/de/hpi/svedeb/operators/workers/NestedLoopJoinWorker.scala
+++ b/src/main/scala/de/hpi/svedeb/operators/workers/NestedLoopJoinWorker.scala
@@ -1,6 +1,6 @@
 package de.hpi.svedeb.operators.workers
 
-import akka.actor.{Actor, ActorLogging, ActorRef}
+import akka.actor.{Actor, ActorLogging, ActorRef, Props}
 import de.hpi.svedeb.operators.workers.NestedLoopJoinWorker.{JoinJob, JoinWorkerState, PartialResult}
 import de.hpi.svedeb.table.Column.{ScanColumn, ScannedValues}
 import de.hpi.svedeb.table.{ColumnType, Partition}
@@ -29,29 +29,49 @@ object NestedLoopJoinWorker {
     }
 
     def saveColumnRefs(partition: ActorRef, leftPartition: ActorRef, rightPartition: ActorRef, columns: Map[String, ActorRef]): JoinWorkerState = {
-      if (partition == leftPartition) JoinWorkerState(sender, Some(columns), rightColumnRefs, leftColumnValues, rightColumnValues, postJoin, result)
-      else JoinWorkerState(sender, leftColumnRefs, Some(columns), leftColumnValues, rightColumnValues, postJoin, result)
+      if (partition == leftPartition) {
+        JoinWorkerState(sender, Some(columns), rightColumnRefs, leftColumnValues, rightColumnValues, postJoin, result)
+      } else if (partition == rightPartition) {
+        JoinWorkerState(sender, leftColumnRefs, Some(columns), leftColumnValues, rightColumnValues, postJoin, result)
+      } else {
+        throw new Exception(s"Unexpected sender $partition")
+      }
     }
 
-    def saveColumnValues(partition: ActorRef, leftPartition: ActorRef, rightPartition: ActorRef, column: ColumnType): JoinWorkerState = {
-      if (partition == leftPartition) JoinWorkerState(sender, leftColumnRefs, rightColumnRefs, Some(column), rightColumnValues, postJoin, result)
-      else JoinWorkerState(sender, leftColumnRefs, rightColumnRefs, leftColumnValues, Some(column), postJoin, result)
+    def saveColumnValues(columnRef: ActorRef, leftJoinColumn: ActorRef, rightJoinColumn: ActorRef, column: ColumnType): JoinWorkerState = {
+      if (columnRef == leftJoinColumn) {
+        JoinWorkerState(sender, leftColumnRefs, rightColumnRefs, Some(column), rightColumnValues, postJoin, result)
+      } else if (columnRef == rightJoinColumn) {
+        JoinWorkerState(sender, leftColumnRefs, rightColumnRefs, leftColumnValues, Some(column), postJoin, result)
+      } else {
+        throw new Exception(s"Unexpected sender $columnRef")
+      }
     }
 
     def enterPostJoin(): JoinWorkerState = {
       JoinWorkerState(sender, leftColumnRefs, rightColumnRefs, leftColumnValues, rightColumnValues, postJoin = true, result)
     }
   }
+
+  def props(leftPartition: ActorRef,
+            rightPartition: ActorRef,
+            resultPartitionId: Int,
+            leftJoinColumn: String,
+            rightJoinColumn: String,
+            predicate: (String, String) => Boolean): Props =
+    Props(new NestedLoopJoinWorker(leftPartition, rightPartition, resultPartitionId, leftJoinColumn, rightJoinColumn, predicate))
 }
 
 class NestedLoopJoinWorker(leftPartition: ActorRef,
                            rightPartition: ActorRef,
                            resultPartitionId: Int,
                            leftJoinColumn: String,
-                           rightJoinColumn: String) extends Actor with ActorLogging {
+                           rightJoinColumn: String,
+                           predicate: (String, String) => Boolean) extends Actor with ActorLogging {
   override def receive: Receive = active(JoinWorkerState(None, None, None, None, None))
 
   private def beginJoinJob(state: JoinWorkerState): Unit = {
+    log.debug("Beginning Join Job")
     val newState = state.storeSender(sender())
     context.become(active(newState))
 
@@ -60,6 +80,7 @@ class NestedLoopJoinWorker(leftPartition: ActorRef,
   }
 
   def handleColumnsRetrieved(state: JoinWorkerState, columns: Map[String, ActorRef]): Unit = {
+    log.debug("Handle columns retrieved")
     val newState = state.saveColumnRefs(sender(), leftPartition, rightPartition, columns)
     context.become(active(newState))
 
@@ -70,6 +91,7 @@ class NestedLoopJoinWorker(leftPartition: ActorRef,
   }
 
   def handleScannedValues(state: JoinWorkerState, columnName: String, values: ColumnType): Unit = {
+    log.debug("Handle scanned values")
     if (state.postJoin) {
       storeResult(state, columnName, values)
     } else {
@@ -81,7 +103,10 @@ class NestedLoopJoinWorker(leftPartition: ActorRef,
     val newState = state.addResultForColumn(columnName, values)
     context.become(active(newState))
 
+    log.debug("Received a result")
+
     if (newState.leftColumnRefs.get.size + newState.rightColumnRefs.get.size == newState.result.size) {
+      log.debug("Computed final result")
       if (newState.result.forall(_._2.values.isEmpty)) {
         newState.sender.get ! PartialResult(resultPartitionId, None)
       } else {
@@ -92,16 +117,19 @@ class NestedLoopJoinWorker(leftPartition: ActorRef,
   }
 
   private def handleJoinInput(state: JoinWorkerState, values: ColumnType): Unit = {
-    val newState = state.saveColumnValues(sender(), leftPartition, rightPartition, values)
+    val newState = state.saveColumnValues(sender(), state.leftColumnRefs.get.apply(leftJoinColumn), state.rightColumnRefs.get.apply(rightJoinColumn), values)
     context.become(active(newState))
 
+    log.debug("Received Join input")
+
     if (newState.leftColumnValues.isDefined && newState.rightColumnValues.isDefined) {
+      log.debug("Performing join")
       val indexedLeft = newState.leftColumnValues.get.values.zipWithIndex
       val indexedRight = newState.rightColumnValues.get.values.zipWithIndex
 
       val joinedIndices = indexedLeft.flatMap { case (leftValue, leftIndex) =>
         indexedRight.flatMap { case (rightValue, rightIndex) =>
-          if (leftValue == rightValue) Some(leftIndex, rightIndex)
+          if (predicate(leftValue,rightValue)) Some(leftIndex, rightIndex)
           else None
         }
       }
@@ -117,7 +145,7 @@ class NestedLoopJoinWorker(leftPartition: ActorRef,
   def active(state: JoinWorkerState): Receive = {
     case JoinJob() => beginJoinJob(state)
     case ColumnsRetrieved(columns) => handleColumnsRetrieved(state, columns)
-    case ScannedValues(partitionId, columnName, values) => handleScannedValues(state, columnName, values)
+    case ScannedValues(_, columnName, values) => handleScannedValues(state, columnName, values)
     case m => throw new Exception(s"Message not understood: $m")
   }
 }

--- a/src/test/scala/de/hpi/svedeb/AbstractActorTest.scala
+++ b/src/test/scala/de/hpi/svedeb/AbstractActorTest.scala
@@ -1,11 +1,11 @@
 package de.hpi.svedeb
 
 import akka.actor.{ActorRef, ActorSystem}
-import akka.testkit.{ImplicitSender, TestKit}
-import de.hpi.svedeb.table.Column.{ScanColumn, ScannedValues}
+import akka.testkit.{ImplicitSender, TestActor, TestKit, TestProbe}
+import de.hpi.svedeb.table.Column._
 import de.hpi.svedeb.table.ColumnType
-import de.hpi.svedeb.table.Partition.{ColumnsRetrieved, GetColumns}
-import de.hpi.svedeb.table.Table.{GetPartitions, PartitionsInTable}
+import de.hpi.svedeb.table.Partition._
+import de.hpi.svedeb.table.Table._
 import org.scalatest.Matchers._
 
 abstract class AbstractActorTest(name: String) extends TestKit(ActorSystem(name))
@@ -38,6 +38,59 @@ abstract class AbstractActorTest(name: String) extends TestKit(ActorSystem(name)
     val partitions = expectMsgType[PartitionsInTable]
     partitions.partitions.size shouldEqual expectedTable.size
     partitions.partitions.zipWithIndex.foreach{ case (partition, id) => checkPartition(partition, expectedTable(id))}
+  }
+
+  def generateColumnTestProbe(partitionId: Int, columnName: String, columnDefinition: ColumnType): ActorRef = {
+    val column = TestProbe("Column")
+
+    column.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
+      case ScanColumn(None) => sender.tell(ScannedValues(partitionId, columnName, columnDefinition), column.ref); TestActor.KeepRunning
+      case ScanColumn(Some(indices)) => sender.tell(ScannedValues(partitionId, columnName, columnDefinition.filterByIndices(indices)), column.ref); TestActor.KeepRunning
+      case AppendValue(_) => sender.tell(ValueAppended(partitionId, columnName), column.ref); TestActor.KeepRunning
+      case FilterColumn(predicate) => sender.tell(FilteredRowIndices(partitionId, columnName, columnDefinition.filterByPredicate(predicate)), column.ref); TestActor.KeepRunning
+    })
+
+    column.ref
+  }
+
+  def generatePartitionTestProbe(partitionId: Int, partitionDefinition: Map[String, ColumnType]): (ActorRef, Map[String, ActorRef]) = {
+    val partition = TestProbe("Partition")
+
+    val columns = partitionDefinition.map{ case (columnName, values) => (columnName, generateColumnTestProbe(partitionId, columnName, values))}
+
+    partition.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
+      case ListColumnNames() => sender.tell(ColumnNameList(partitionDefinition.keys.toSeq), partition.ref); TestActor.KeepRunning
+      case GetColumns() => sender.tell(ColumnsRetrieved(columns), partition.ref); TestActor.KeepRunning
+      case GetColumn(columnName) => sender.tell(ColumnRetrieved(partitionId, columnName, columns(columnName)), partition.ref); TestActor.KeepRunning
+      case m => throw new Exception("Unexpected message type")
+    })
+
+    (partition.ref, columns)
+  }
+
+  def generateTableTestProbe(tableDefinition: Seq[Map[String, ColumnType]]): ActorRef = {
+    val table = TestProbe("Table")
+
+    val partitionsWithColumns = tableDefinition.zipWithIndex.map { case (partitionDefinition, partitionId) => generatePartitionTestProbe(partitionId, partitionDefinition)}
+    val partitions = partitionsWithColumns.map(_._1)
+
+    table.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
+      case GetPartitions() => sender.tell(PartitionsInTable(partitions), table.ref); TestActor.KeepRunning
+      case ListColumnsInTable() => {
+        if (tableDefinition.isEmpty) {
+          sender.tell(ColumnList(Seq.empty), table.ref)
+        } else {
+          val columnNames = tableDefinition.head.keys.toSeq
+          sender.tell(ColumnList(columnNames), table.ref)
+        }
+      }; TestActor.KeepRunning
+      case GetColumnFromTable(columnName) => {
+        val columns = partitionsWithColumns.map {case (_, map) => map(columnName)}
+        sender.tell(ActorsForColumn(columnName, columns), table.ref)
+      }; TestActor.KeepRunning
+    })
+
+    table.ref
   }
 }
 

--- a/src/test/scala/de/hpi/svedeb/operators/NestedLoopJoinOperatorTest.scala
+++ b/src/test/scala/de/hpi/svedeb/operators/NestedLoopJoinOperatorTest.scala
@@ -1,0 +1,108 @@
+package de.hpi.svedeb.operators
+
+import akka.actor.ActorRef
+import akka.testkit.{TestActor, TestProbe}
+import de.hpi.svedeb.AbstractActorTest
+import de.hpi.svedeb.operators.AbstractOperator.{Execute, QueryResult}
+import de.hpi.svedeb.table.Column.{ScanColumn, ScannedValues}
+import de.hpi.svedeb.table.ColumnType
+import de.hpi.svedeb.table.Partition.{ColumnsRetrieved, GetColumns}
+import de.hpi.svedeb.table.Table.{ColumnList, GetPartitions, ListColumnsInTable, PartitionsInTable}
+
+class NestedLoopJoinOperatorTest extends AbstractActorTest("NestedLoopJoinOperator") {
+  "A nested loop join operator" should "join two tables" in {
+    val leftColumn = TestProbe("LeftColumn")
+    leftColumn.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
+      case ScanColumn(None) => sender.tell(ScannedValues(0, "a", ColumnType("a", "b")), leftColumn.ref); TestActor.KeepRunning
+      case ScanColumn(Some(_)) => sender ! ScannedValues(0, "a", ColumnType("b")); TestActor.KeepRunning
+    })
+
+    val rightColumn = TestProbe("RightColumn")
+    rightColumn.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
+      case ScanColumn(None) => sender.tell(ScannedValues(0, "b", ColumnType("b", "c")), rightColumn.ref); TestActor.KeepRunning
+      case ScanColumn(Some(_)) => sender ! ScannedValues(0, "b", ColumnType("b")); TestActor.KeepRunning
+    })
+
+    val leftPartition = TestProbe("LeftPartition")
+    leftPartition.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
+      case GetColumns() ⇒ sender.tell(ColumnsRetrieved(Map("a" -> leftColumn.ref)), leftPartition.ref); TestActor.KeepRunning
+    })
+
+    val rightPartition = TestProbe("RightPartition")
+    rightPartition.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
+      case GetColumns() ⇒ sender.tell(ColumnsRetrieved(Map("b" -> rightColumn.ref)), rightPartition.ref); TestActor.KeepRunning
+    })
+
+    val leftTable = TestProbe("LeftTable")
+    leftTable.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
+      case GetPartitions() ⇒ sender.tell(PartitionsInTable(Seq(leftPartition.ref)), leftTable.ref); TestActor.KeepRunning
+      case ListColumnsInTable() => sender.tell(ColumnList(Seq("a")), leftTable.ref); TestActor.KeepRunning
+    })
+
+    val rightTable = TestProbe("LeftTable")
+    rightTable.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
+      case GetPartitions() ⇒ sender.tell(PartitionsInTable(Seq(rightPartition.ref)), rightTable.ref); TestActor.KeepRunning
+      case ListColumnsInTable() => sender.tell(ColumnList(Seq("b")), rightTable.ref); TestActor.KeepRunning
+    })
+
+    val operator = system.actorOf(NestedLoopJoinOperator.props(leftTable.ref, rightTable.ref, "a", "b", _ == _))
+    operator ! Execute()
+
+    val result = expectMsgType[QueryResult]
+    checkTable(result.resultTable, Seq(Map("a" -> ColumnType("b"), "b" -> ColumnType("b"))))
+  }
+
+  it should "handle multiple columns" in {
+    val leftColumn1 = TestProbe("LeftColumn1")
+    leftColumn1.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
+      case ScanColumn(None) => sender.tell(ScannedValues(0, "a", ColumnType("a", "b")), leftColumn1.ref); TestActor.KeepRunning
+      case ScanColumn(Some(_)) => sender ! ScannedValues(0, "a", ColumnType("b")); TestActor.KeepRunning
+    })
+
+    val leftColumn2 = TestProbe("LeftColumn2")
+    leftColumn2.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
+      case ScanColumn(None) => sender.tell(ScannedValues(0, "a2", ColumnType("x", "y")), leftColumn2.ref); TestActor.KeepRunning
+      case ScanColumn(Some(_)) => sender ! ScannedValues(0, "a2", ColumnType("y")); TestActor.KeepRunning
+    })
+
+    val rightColumn1 = TestProbe("RightColumn1")
+    rightColumn1.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
+      case ScanColumn(None) => sender.tell(ScannedValues(0, "b", ColumnType("b", "c")), rightColumn1.ref); TestActor.KeepRunning
+      case ScanColumn(Some(_)) => sender ! ScannedValues(0, "b", ColumnType("b")); TestActor.KeepRunning
+    })
+
+    val rightColumn2 = TestProbe("RightColumn2")
+    rightColumn2.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
+      case ScanColumn(None) => sender.tell(ScannedValues(0, "b2", ColumnType("u", "v")), rightColumn2.ref); TestActor.KeepRunning
+      case ScanColumn(Some(_)) => sender ! ScannedValues(0, "b2", ColumnType("v")); TestActor.KeepRunning
+    })
+
+    val leftPartition = TestProbe("LeftPartition")
+    leftPartition.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
+      case GetColumns() ⇒ sender.tell(ColumnsRetrieved(Map("a" -> leftColumn1.ref, "a2" -> leftColumn2.ref)), leftPartition.ref); TestActor.KeepRunning
+    })
+
+    val rightPartition = TestProbe("RightPartition")
+    rightPartition.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
+      case GetColumns() ⇒ sender.tell(ColumnsRetrieved(Map("b" -> rightColumn1.ref, "b2" -> rightColumn2.ref)), rightPartition.ref); TestActor.KeepRunning
+    })
+
+    val leftTable = TestProbe("LeftTable")
+    leftTable.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
+      case GetPartitions() ⇒ sender.tell(PartitionsInTable(Seq(leftPartition.ref)), leftTable.ref); TestActor.KeepRunning
+      case ListColumnsInTable() => sender.tell(ColumnList(Seq("a")), leftTable.ref); TestActor.KeepRunning
+    })
+
+    val rightTable = TestProbe("LeftTable")
+    rightTable.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
+      case GetPartitions() ⇒ sender.tell(PartitionsInTable(Seq(rightPartition.ref)), rightTable.ref); TestActor.KeepRunning
+      case ListColumnsInTable() => sender.tell(ColumnList(Seq("b")), rightTable.ref); TestActor.KeepRunning
+    })
+
+    val operator = system.actorOf(NestedLoopJoinOperator.props(leftTable.ref, rightTable.ref, "a", "b", _ == _))
+    operator ! Execute()
+
+    val result = expectMsgType[QueryResult]
+    checkTable(result.resultTable, Seq(Map("a" -> ColumnType("b"), "a2" -> ColumnType("y"), "b" -> ColumnType("b"), "b2" -> ColumnType("v"))))
+  }
+}

--- a/src/test/scala/de/hpi/svedeb/operators/NestedLoopJoinOperatorTest.scala
+++ b/src/test/scala/de/hpi/svedeb/operators/NestedLoopJoinOperatorTest.scala
@@ -1,52 +1,17 @@
 package de.hpi.svedeb.operators
 
-import akka.actor.ActorRef
-import akka.testkit.{TestActor, TestProbe}
 import de.hpi.svedeb.AbstractActorTest
 import de.hpi.svedeb.operators.AbstractOperator.{Execute, QueryResult}
-import de.hpi.svedeb.table.Column.{ScanColumn, ScannedValues}
 import de.hpi.svedeb.table.ColumnType
-import de.hpi.svedeb.table.Partition.{ColumnsRetrieved, GetColumns}
-import de.hpi.svedeb.table.Table.{ColumnList, GetPartitions, ListColumnsInTable, PartitionsInTable}
 import org.scalatest.Matchers._
 
 class NestedLoopJoinOperatorTest extends AbstractActorTest("NestedLoopJoinOperator") {
   "A nested loop join operator" should "join two tables" in {
-    val leftColumn = TestProbe("LeftColumn")
-    leftColumn.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
-      case ScanColumn(None) => sender.tell(ScannedValues(0, "a", ColumnType("a", "b")), leftColumn.ref); TestActor.KeepRunning
-      case ScanColumn(Some(_)) => sender ! ScannedValues(0, "a", ColumnType("b")); TestActor.KeepRunning
-    })
 
-    val rightColumn = TestProbe("RightColumn")
-    rightColumn.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
-      case ScanColumn(None) => sender.tell(ScannedValues(0, "b", ColumnType("b", "c")), rightColumn.ref); TestActor.KeepRunning
-      case ScanColumn(Some(_)) => sender ! ScannedValues(0, "b", ColumnType("b")); TestActor.KeepRunning
-    })
+    val leftTable = generateTableTestProbe(Seq(Map("a" -> ColumnType("a", "b"))))
+    val rightTable = generateTableTestProbe(Seq(Map("b" -> ColumnType("b", "c"))))
 
-    val leftPartition = TestProbe("LeftPartition")
-    leftPartition.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
-      case GetColumns() ⇒ sender.tell(ColumnsRetrieved(Map("a" -> leftColumn.ref)), leftPartition.ref); TestActor.KeepRunning
-    })
-
-    val rightPartition = TestProbe("RightPartition")
-    rightPartition.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
-      case GetColumns() ⇒ sender.tell(ColumnsRetrieved(Map("b" -> rightColumn.ref)), rightPartition.ref); TestActor.KeepRunning
-    })
-
-    val leftTable = TestProbe("LeftTable")
-    leftTable.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
-      case GetPartitions() ⇒ sender.tell(PartitionsInTable(Seq(leftPartition.ref)), leftTable.ref); TestActor.KeepRunning
-      case ListColumnsInTable() => sender.tell(ColumnList(Seq("a")), leftTable.ref); TestActor.KeepRunning
-    })
-
-    val rightTable = TestProbe("LeftTable")
-    rightTable.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
-      case GetPartitions() ⇒ sender.tell(PartitionsInTable(Seq(rightPartition.ref)), rightTable.ref); TestActor.KeepRunning
-      case ListColumnsInTable() => sender.tell(ColumnList(Seq("b")), rightTable.ref); TestActor.KeepRunning
-    })
-
-    val operator = system.actorOf(NestedLoopJoinOperator.props(leftTable.ref, rightTable.ref, "a", "b", _ == _))
+    val operator = system.actorOf(NestedLoopJoinOperator.props(leftTable, rightTable, "a", "b", _ == _))
     operator ! Execute()
 
     val result = expectMsgType[QueryResult]
@@ -54,120 +19,23 @@ class NestedLoopJoinOperatorTest extends AbstractActorTest("NestedLoopJoinOperat
   }
 
   it should "handle multiple columns" in {
-    val leftColumn1 = TestProbe("LeftColumn1")
-    leftColumn1.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
-      case ScanColumn(None) => sender.tell(ScannedValues(0, "a", ColumnType("a", "b")), leftColumn1.ref); TestActor.KeepRunning
-      case ScanColumn(Some(_)) => sender ! ScannedValues(0, "a", ColumnType("b")); TestActor.KeepRunning
-    })
 
-    val leftColumn2 = TestProbe("LeftColumn2")
-    leftColumn2.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
-      case ScanColumn(None) => sender.tell(ScannedValues(0, "a2", ColumnType("x", "y")), leftColumn2.ref); TestActor.KeepRunning
-      case ScanColumn(Some(_)) => sender ! ScannedValues(0, "a2", ColumnType("y")); TestActor.KeepRunning
-    })
+    val leftTable = generateTableTestProbe(Seq(Map("a" -> ColumnType("a", "b"), "a2" -> ColumnType("x", "y"))))
+    val rightTable = generateTableTestProbe(Seq(Map("b" -> ColumnType("b", "c"), "b2" -> ColumnType("u", "v"))))
 
-    val rightColumn1 = TestProbe("RightColumn1")
-    rightColumn1.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
-      case ScanColumn(None) => sender.tell(ScannedValues(0, "b", ColumnType("b", "c")), rightColumn1.ref); TestActor.KeepRunning
-      case ScanColumn(Some(_)) => sender ! ScannedValues(0, "b", ColumnType("b")); TestActor.KeepRunning
-    })
-
-    val rightColumn2 = TestProbe("RightColumn2")
-    rightColumn2.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
-      case ScanColumn(None) => sender.tell(ScannedValues(0, "b2", ColumnType("u", "v")), rightColumn2.ref); TestActor.KeepRunning
-      case ScanColumn(Some(_)) => sender ! ScannedValues(0, "b2", ColumnType("v")); TestActor.KeepRunning
-    })
-
-    val leftPartition = TestProbe("LeftPartition")
-    leftPartition.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
-      case GetColumns() ⇒ sender.tell(ColumnsRetrieved(Map("a" -> leftColumn1.ref, "a2" -> leftColumn2.ref)), leftPartition.ref); TestActor.KeepRunning
-    })
-
-    val rightPartition = TestProbe("RightPartition")
-    rightPartition.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
-      case GetColumns() ⇒ sender.tell(ColumnsRetrieved(Map("b" -> rightColumn1.ref, "b2" -> rightColumn2.ref)), rightPartition.ref); TestActor.KeepRunning
-    })
-
-    val leftTable = TestProbe("LeftTable")
-    leftTable.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
-      case GetPartitions() ⇒ sender.tell(PartitionsInTable(Seq(leftPartition.ref)), leftTable.ref); TestActor.KeepRunning
-      case ListColumnsInTable() => sender.tell(ColumnList(Seq("a")), leftTable.ref); TestActor.KeepRunning
-    })
-
-    val rightTable = TestProbe("LeftTable")
-    rightTable.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
-      case GetPartitions() ⇒ sender.tell(PartitionsInTable(Seq(rightPartition.ref)), rightTable.ref); TestActor.KeepRunning
-      case ListColumnsInTable() => sender.tell(ColumnList(Seq("b")), rightTable.ref); TestActor.KeepRunning
-    })
-
-    val operator = system.actorOf(NestedLoopJoinOperator.props(leftTable.ref, rightTable.ref, "a", "b", _ == _))
+    val operator = system.actorOf(NestedLoopJoinOperator.props(leftTable, rightTable, "a", "b", _ == _))
     operator ! Execute()
 
     val result = expectMsgType[QueryResult]
-    checkTable(result.resultTable, Seq(Map("a" -> ColumnType("b"), "a2" -> ColumnType("y"), "b" -> ColumnType("b"), "b2" -> ColumnType("v"))))
+    checkTable(result.resultTable, Seq(Map("a" -> ColumnType("b"), "a2" -> ColumnType("y"), "b" -> ColumnType("b"), "b2" -> ColumnType("u"))))
   }
 
   it should "handle multiple partitions" in {
-    val leftColumn1 = TestProbe("LeftColumn1")
-    leftColumn1.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
-      case ScanColumn(None) => sender.tell(ScannedValues(0, "a", ColumnType("a", "b")), leftColumn1.ref); TestActor.KeepRunning
-      case ScanColumn(Some(Seq())) => throw new Exception("Should not")
-      case ScanColumn(Some(Seq(1))) => sender ! ScannedValues(0, "a", ColumnType("b")); TestActor.KeepRunning
-    })
 
-    val leftColumn2 = TestProbe("LeftColumn2")
-    leftColumn2.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
-      case ScanColumn(None) => sender.tell(ScannedValues(0, "a", ColumnType("c", "d")), leftColumn2.ref); TestActor.KeepRunning
-      case ScanColumn(Some(Seq(0))) => sender ! ScannedValues(0, "a", ColumnType("c")); TestActor.KeepRunning
-      case ScanColumn(Some(Seq(1))) => sender ! ScannedValues(0, "a", ColumnType("d")); TestActor.KeepRunning
-    })
+    val leftTable = generateTableTestProbe(Seq(Map("a" -> ColumnType("a", "b")), Map("a" -> ColumnType("c", "d"))))
+    val rightTable = generateTableTestProbe(Seq(Map("b" -> ColumnType("b", "c")), Map("b" -> ColumnType("d", "e"))))
 
-    val rightColumn1 = TestProbe("RightColumn1")
-    rightColumn1.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
-      case ScanColumn(None) => sender.tell(ScannedValues(0, "b", ColumnType("b", "c")), rightColumn1.ref); TestActor.KeepRunning
-      case ScanColumn(Some(Seq(0))) => sender ! ScannedValues(0, "b", ColumnType("b")); TestActor.KeepRunning
-      case ScanColumn(Some(Seq(1))) => sender ! ScannedValues(0, "b", ColumnType("c")); TestActor.KeepRunning
-    })
-
-    val rightColumn2 = TestProbe("RightColumn2")
-    rightColumn2.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
-      case ScanColumn(None) => sender.tell(ScannedValues(0, "b", ColumnType("d", "e")), rightColumn2.ref); TestActor.KeepRunning
-      case ScanColumn(Some(Seq(0))) => sender ! ScannedValues(0, "b", ColumnType("d")); TestActor.KeepRunning
-    })
-
-    val leftPartition1 = TestProbe("LeftPartition1")
-    leftPartition1.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
-      case GetColumns() ⇒ sender.tell(ColumnsRetrieved(Map("a" -> leftColumn1.ref)), leftPartition1.ref); TestActor.KeepRunning
-    })
-
-    val leftPartition2 = TestProbe("LeftPartition1")
-    leftPartition2.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
-      case GetColumns() ⇒ sender.tell(ColumnsRetrieved(Map("a" -> leftColumn2.ref)), leftPartition2.ref); TestActor.KeepRunning
-    })
-
-    val rightPartition1 = TestProbe("RightPartition1")
-    rightPartition1.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
-      case GetColumns() ⇒ sender.tell(ColumnsRetrieved(Map("b" -> rightColumn1.ref)), rightPartition1.ref); TestActor.KeepRunning
-    })
-
-    val rightPartition2 = TestProbe("RightPartition2")
-    rightPartition2.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
-      case GetColumns() ⇒ sender.tell(ColumnsRetrieved(Map("b" -> rightColumn2.ref)), rightPartition2.ref); TestActor.KeepRunning
-    })
-
-    val leftTable = TestProbe("LeftTable")
-    leftTable.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
-      case GetPartitions() ⇒ sender.tell(PartitionsInTable(Seq(leftPartition1.ref, leftPartition2.ref)), leftTable.ref); TestActor.KeepRunning
-      case ListColumnsInTable() => sender.tell(ColumnList(Seq("a")), leftTable.ref); TestActor.KeepRunning
-    })
-
-    val rightTable = TestProbe("LeftTable")
-    rightTable.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
-      case GetPartitions() ⇒ sender.tell(PartitionsInTable(Seq(rightPartition1.ref, rightPartition2.ref)), rightTable.ref); TestActor.KeepRunning
-      case ListColumnsInTable() => sender.tell(ColumnList(Seq("b")), rightTable.ref); TestActor.KeepRunning
-    })
-
-    val operator = system.actorOf(NestedLoopJoinOperator.props(leftTable.ref, rightTable.ref, "a", "b", _ == _))
+    val operator = system.actorOf(NestedLoopJoinOperator.props(leftTable, rightTable, "a", "b", _ == _))
     operator ! Execute()
 
     val result = expectMsgType[QueryResult]
@@ -178,68 +46,28 @@ class NestedLoopJoinOperatorTest extends AbstractActorTest("NestedLoopJoinOperat
   }
 
   it should "handle multiple partitions (part2)" in {
-    val leftColumn1 = TestProbe("LeftColumn1")
-    leftColumn1.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
-      case ScanColumn(None) => sender.tell(ScannedValues(0, "a", ColumnType("a", "b", "c")), leftColumn1.ref); TestActor.KeepRunning
-      case ScanColumn(Some(Seq(1, 2))) => sender ! ScannedValues(0, "a", ColumnType("b", "c")); TestActor.KeepRunning
-    })
 
-    val leftColumn2 = TestProbe("LeftColumn2")
-    leftColumn2.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
-      case ScanColumn(None) => sender.tell(ScannedValues(0, "a", ColumnType("d")), leftColumn2.ref); TestActor.KeepRunning
-      case ScanColumn(Some(Seq(0))) => sender ! ScannedValues(0, "a", ColumnType("d")); TestActor.KeepRunning
-    })
+    val leftTable = generateTableTestProbe(Seq(Map("a" -> ColumnType("a", "b", "c")), Map("a" -> ColumnType("d"))))
+    val rightTable = generateTableTestProbe(Seq(Map("b" -> ColumnType("b", "c")), Map("b" -> ColumnType("d", "e"))))
 
-    val rightColumn1 = TestProbe("RightColumn1")
-    rightColumn1.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
-      case ScanColumn(None) => sender.tell(ScannedValues(0, "b", ColumnType("b", "c")), rightColumn1.ref); TestActor.KeepRunning
-      case ScanColumn(Some(Seq(0, 1))) => sender ! ScannedValues(0, "b", ColumnType("b", "c")); TestActor.KeepRunning
-    })
-
-    val rightColumn2 = TestProbe("RightColumn2")
-    rightColumn2.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
-      case ScanColumn(None) => sender.tell(ScannedValues(0, "b", ColumnType("d", "e")), rightColumn2.ref); TestActor.KeepRunning
-      case ScanColumn(Some(Seq(0))) => sender ! ScannedValues(0, "b", ColumnType("d")); TestActor.KeepRunning
-    })
-
-    val leftPartition1 = TestProbe("LeftPartition1")
-    leftPartition1.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
-      case GetColumns() ⇒ sender.tell(ColumnsRetrieved(Map("a" -> leftColumn1.ref)), leftPartition1.ref); TestActor.KeepRunning
-    })
-
-    val leftPartition2 = TestProbe("LeftPartition1")
-    leftPartition2.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
-      case GetColumns() ⇒ sender.tell(ColumnsRetrieved(Map("a" -> leftColumn2.ref)), leftPartition2.ref); TestActor.KeepRunning
-    })
-
-    val rightPartition1 = TestProbe("RightPartition1")
-    rightPartition1.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
-      case GetColumns() ⇒ sender.tell(ColumnsRetrieved(Map("b" -> rightColumn1.ref)), rightPartition1.ref); TestActor.KeepRunning
-    })
-
-    val rightPartition2 = TestProbe("RightPartition2")
-    rightPartition2.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
-      case GetColumns() ⇒ sender.tell(ColumnsRetrieved(Map("b" -> rightColumn2.ref)), rightPartition2.ref); TestActor.KeepRunning
-    })
-
-    val leftTable = TestProbe("LeftTable")
-    leftTable.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
-      case GetPartitions() ⇒ sender.tell(PartitionsInTable(Seq(leftPartition1.ref, leftPartition2.ref)), leftTable.ref); TestActor.KeepRunning
-      case ListColumnsInTable() => sender.tell(ColumnList(Seq("a")), leftTable.ref); TestActor.KeepRunning
-    })
-
-    val rightTable = TestProbe("LeftTable")
-    rightTable.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
-      case GetPartitions() ⇒ sender.tell(PartitionsInTable(Seq(rightPartition1.ref, rightPartition2.ref)), rightTable.ref); TestActor.KeepRunning
-      case ListColumnsInTable() => sender.tell(ColumnList(Seq("b")), rightTable.ref); TestActor.KeepRunning
-    })
-
-    val operator = system.actorOf(NestedLoopJoinOperator.props(leftTable.ref, rightTable.ref, "a", "b", _ == _))
+    val operator = system.actorOf(NestedLoopJoinOperator.props(leftTable, rightTable, "a", "b", _ == _))
     operator ! Execute()
 
     val result = expectMsgType[QueryResult]
     checkTable(result.resultTable, Seq(
       Map("a" -> ColumnType("b", "c"), "b" -> ColumnType("b", "c")),
       Map("a" -> ColumnType("d"), "b" -> ColumnType("d"))))
+  }
+
+  it should "handle inequality joins" in {
+
+    val leftTable = generateTableTestProbe(Seq(Map("a" -> ColumnType("a", "b", "c"))))
+    val rightTable = generateTableTestProbe(Seq(Map("b" -> ColumnType("b", "c"))))
+
+    val operator = system.actorOf(NestedLoopJoinOperator.props(leftTable, rightTable, "a", "b", _ < _))
+    operator ! Execute()
+
+    val result = expectMsgType[QueryResult]
+    checkTable(result.resultTable, Seq(Map("a" -> ColumnType("a", "a", "b"), "b" -> ColumnType("b", "c", "c"))))
   }
 }

--- a/src/test/scala/de/hpi/svedeb/operators/NestedLoopJoinOperatorTest.scala
+++ b/src/test/scala/de/hpi/svedeb/operators/NestedLoopJoinOperatorTest.scala
@@ -8,6 +8,7 @@ import de.hpi.svedeb.table.Column.{ScanColumn, ScannedValues}
 import de.hpi.svedeb.table.ColumnType
 import de.hpi.svedeb.table.Partition.{ColumnsRetrieved, GetColumns}
 import de.hpi.svedeb.table.Table.{ColumnList, GetPartitions, ListColumnsInTable, PartitionsInTable}
+import org.scalatest.Matchers._
 
 class NestedLoopJoinOperatorTest extends AbstractActorTest("NestedLoopJoinOperator") {
   "A nested loop join operator" should "join two tables" in {
@@ -110,25 +111,28 @@ class NestedLoopJoinOperatorTest extends AbstractActorTest("NestedLoopJoinOperat
     val leftColumn1 = TestProbe("LeftColumn1")
     leftColumn1.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
       case ScanColumn(None) => sender.tell(ScannedValues(0, "a", ColumnType("a", "b")), leftColumn1.ref); TestActor.KeepRunning
-      case ScanColumn(Some(_)) => sender ! ScannedValues(0, "a", ColumnType("b")); TestActor.KeepRunning
+      case ScanColumn(Some(Seq())) => throw new Exception("Should not")
+      case ScanColumn(Some(Seq(1))) => sender ! ScannedValues(0, "a", ColumnType("b")); TestActor.KeepRunning
     })
 
     val leftColumn2 = TestProbe("LeftColumn2")
     leftColumn2.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
       case ScanColumn(None) => sender.tell(ScannedValues(0, "a", ColumnType("c", "d")), leftColumn2.ref); TestActor.KeepRunning
-      case ScanColumn(Some(_)) => sender ! ScannedValues(0, "a", ColumnType("c", "d")); TestActor.KeepRunning
+      case ScanColumn(Some(Seq(0))) => sender ! ScannedValues(0, "a", ColumnType("c")); TestActor.KeepRunning
+      case ScanColumn(Some(Seq(1))) => sender ! ScannedValues(0, "a", ColumnType("d")); TestActor.KeepRunning
     })
 
     val rightColumn1 = TestProbe("RightColumn1")
     rightColumn1.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
       case ScanColumn(None) => sender.tell(ScannedValues(0, "b", ColumnType("b", "c")), rightColumn1.ref); TestActor.KeepRunning
-      case ScanColumn(Some(_)) => sender ! ScannedValues(0, "b", ColumnType("b", "c")); TestActor.KeepRunning
+      case ScanColumn(Some(Seq(0))) => sender ! ScannedValues(0, "b", ColumnType("b")); TestActor.KeepRunning
+      case ScanColumn(Some(Seq(1))) => sender ! ScannedValues(0, "b", ColumnType("c")); TestActor.KeepRunning
     })
 
     val rightColumn2 = TestProbe("RightColumn2")
     rightColumn2.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
       case ScanColumn(None) => sender.tell(ScannedValues(0, "b", ColumnType("d", "e")), rightColumn2.ref); TestActor.KeepRunning
-      case ScanColumn(Some(_)) => sender ! ScannedValues(0, "b", ColumnType("d")); TestActor.KeepRunning
+      case ScanColumn(Some(Seq(0))) => sender ! ScannedValues(0, "b", ColumnType("d")); TestActor.KeepRunning
     })
 
     val leftPartition1 = TestProbe("LeftPartition1")
@@ -170,7 +174,72 @@ class NestedLoopJoinOperatorTest extends AbstractActorTest("NestedLoopJoinOperat
     checkTable(result.resultTable, Seq(
       Map("a" -> ColumnType("b"), "b" -> ColumnType("b")),
       Map("a" -> ColumnType("c"), "b" -> ColumnType("c")),
-      Map("a" -> ColumnType("d"), "b" -> ColumnType("d")),
-      Map.empty))
+      Map("a" -> ColumnType("d"), "b" -> ColumnType("d"))))
+  }
+
+  it should "handle multiple partitions (part2)" in {
+    val leftColumn1 = TestProbe("LeftColumn1")
+    leftColumn1.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
+      case ScanColumn(None) => sender.tell(ScannedValues(0, "a", ColumnType("a", "b", "c")), leftColumn1.ref); TestActor.KeepRunning
+      case ScanColumn(Some(Seq(1, 2))) => sender ! ScannedValues(0, "a", ColumnType("b", "c")); TestActor.KeepRunning
+    })
+
+    val leftColumn2 = TestProbe("LeftColumn2")
+    leftColumn2.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
+      case ScanColumn(None) => sender.tell(ScannedValues(0, "a", ColumnType("d")), leftColumn2.ref); TestActor.KeepRunning
+      case ScanColumn(Some(Seq(0))) => sender ! ScannedValues(0, "a", ColumnType("d")); TestActor.KeepRunning
+    })
+
+    val rightColumn1 = TestProbe("RightColumn1")
+    rightColumn1.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
+      case ScanColumn(None) => sender.tell(ScannedValues(0, "b", ColumnType("b", "c")), rightColumn1.ref); TestActor.KeepRunning
+      case ScanColumn(Some(Seq(0, 1))) => sender ! ScannedValues(0, "b", ColumnType("b", "c")); TestActor.KeepRunning
+    })
+
+    val rightColumn2 = TestProbe("RightColumn2")
+    rightColumn2.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
+      case ScanColumn(None) => sender.tell(ScannedValues(0, "b", ColumnType("d", "e")), rightColumn2.ref); TestActor.KeepRunning
+      case ScanColumn(Some(Seq(0))) => sender ! ScannedValues(0, "b", ColumnType("d")); TestActor.KeepRunning
+    })
+
+    val leftPartition1 = TestProbe("LeftPartition1")
+    leftPartition1.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
+      case GetColumns() ⇒ sender.tell(ColumnsRetrieved(Map("a" -> leftColumn1.ref)), leftPartition1.ref); TestActor.KeepRunning
+    })
+
+    val leftPartition2 = TestProbe("LeftPartition1")
+    leftPartition2.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
+      case GetColumns() ⇒ sender.tell(ColumnsRetrieved(Map("a" -> leftColumn2.ref)), leftPartition2.ref); TestActor.KeepRunning
+    })
+
+    val rightPartition1 = TestProbe("RightPartition1")
+    rightPartition1.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
+      case GetColumns() ⇒ sender.tell(ColumnsRetrieved(Map("b" -> rightColumn1.ref)), rightPartition1.ref); TestActor.KeepRunning
+    })
+
+    val rightPartition2 = TestProbe("RightPartition2")
+    rightPartition2.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
+      case GetColumns() ⇒ sender.tell(ColumnsRetrieved(Map("b" -> rightColumn2.ref)), rightPartition2.ref); TestActor.KeepRunning
+    })
+
+    val leftTable = TestProbe("LeftTable")
+    leftTable.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
+      case GetPartitions() ⇒ sender.tell(PartitionsInTable(Seq(leftPartition1.ref, leftPartition2.ref)), leftTable.ref); TestActor.KeepRunning
+      case ListColumnsInTable() => sender.tell(ColumnList(Seq("a")), leftTable.ref); TestActor.KeepRunning
+    })
+
+    val rightTable = TestProbe("LeftTable")
+    rightTable.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
+      case GetPartitions() ⇒ sender.tell(PartitionsInTable(Seq(rightPartition1.ref, rightPartition2.ref)), rightTable.ref); TestActor.KeepRunning
+      case ListColumnsInTable() => sender.tell(ColumnList(Seq("b")), rightTable.ref); TestActor.KeepRunning
+    })
+
+    val operator = system.actorOf(NestedLoopJoinOperator.props(leftTable.ref, rightTable.ref, "a", "b", _ == _))
+    operator ! Execute()
+
+    val result = expectMsgType[QueryResult]
+    checkTable(result.resultTable, Seq(
+      Map("a" -> ColumnType("b", "c"), "b" -> ColumnType("b", "c")),
+      Map("a" -> ColumnType("d"), "b" -> ColumnType("d"))))
   }
 }

--- a/src/test/scala/de/hpi/svedeb/operators/ProjectionOperatorTest.scala
+++ b/src/test/scala/de/hpi/svedeb/operators/ProjectionOperatorTest.scala
@@ -1,12 +1,9 @@
 package de.hpi.svedeb.operators
 
-import akka.actor.ActorRef
-import akka.testkit.{TestActor, TestProbe}
+import akka.testkit.TestProbe
 import de.hpi.svedeb.AbstractActorTest
 import de.hpi.svedeb.operators.AbstractOperator.{Execute, QueryResult}
-import de.hpi.svedeb.table.Column.{ScanColumn, ScannedValues}
 import de.hpi.svedeb.table.{ColumnType, Partition, Table}
-import de.hpi.svedeb.table.Table._
 import org.scalatest.Matchers._
 
 class ProjectionOperatorTest extends AbstractActorTest("ProjectionOperator") {
@@ -22,19 +19,8 @@ class ProjectionOperatorTest extends AbstractActorTest("ProjectionOperator") {
   }
 
   "A ProjectionOperator projecting one column" should "return a result table" in {
-    val table = TestProbe("Table")
-    val columnA = TestProbe("a")
-
-    table.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
-      case Nil => TestActor.KeepRunning
-      case GetColumnFromTable("a") => sender ! ActorsForColumn("a", Seq(columnA.ref)); TestActor.KeepRunning
-    })
-
-    columnA.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
-      case ScanColumn(None) => sender ! ScannedValues(0, "a", ColumnType("1", "2", "3")); TestActor.KeepRunning
-    })
-
-    val projectionOperator = system.actorOf(ProjectionOperator.props(table.ref, Seq("a")))
+    val table = generateTableTestProbe(Seq(Map("a" -> ColumnType("1", "2", "3"))))
+    val projectionOperator = system.actorOf(ProjectionOperator.props(table, Seq("a")))
 
     projectionOperator ! Execute()
     val operatorResult = expectMsgType[QueryResult]
@@ -44,29 +30,12 @@ class ProjectionOperatorTest extends AbstractActorTest("ProjectionOperator") {
   }
 
   it should "handle multiple partitions" in {
-    val table = TestProbe("Table")
-    val columnA0 = TestProbe("a")
-    val columnA1 = TestProbe("a")
-    val columnA2 = TestProbe("a")
+    val table = generateTableTestProbe(Seq(
+      Map("a" -> ColumnType("1", "2", "3")),
+      Map("a" -> ColumnType("4", "5", "6")),
+      Map("a" -> ColumnType("7", "8", "9"))))
 
-    table.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
-      case Nil => TestActor.KeepRunning
-      case GetColumnFromTable("a") => sender ! ActorsForColumn("a", Seq(columnA0.ref, columnA1.ref, columnA2.ref)); TestActor.KeepRunning
-    })
-
-    columnA0.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
-      case ScanColumn(None) => sender ! ScannedValues(0, "a", ColumnType("1", "2", "3")); TestActor.KeepRunning
-    })
-
-    columnA1.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
-      case ScanColumn(None) => sender ! ScannedValues(1, "a", ColumnType("4", "5", "6")); TestActor.KeepRunning
-    })
-
-    columnA2.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
-      case ScanColumn(None) => sender ! ScannedValues(2, "a", ColumnType("7", "8", "9")); TestActor.KeepRunning
-    })
-
-    val projectionOperator = system.actorOf(ProjectionOperator.props(table.ref, Seq("a")))
+    val projectionOperator = system.actorOf(ProjectionOperator.props(table, Seq("a")))
 
     projectionOperator ! Execute()
     val operatorResult = expectMsgType[QueryResult]
@@ -93,45 +62,12 @@ class ProjectionOperatorTest extends AbstractActorTest("ProjectionOperator") {
   }
 
   "A ProjectionOperator projecting multiple column" should "handle multiple partitions" in {
-    val table = TestProbe("Table")
-    val columnA0 = TestProbe("a")
-    val columnA1 = TestProbe("a")
-    val columnA2 = TestProbe("a")
-    val columnB0 = TestProbe("b")
-    val columnB1 = TestProbe("b")
-    val columnB2 = TestProbe("b")
+    val table = generateTableTestProbe(Seq(
+      Map("a" -> ColumnType("1", "2", "3"), "b" -> ColumnType("1", "2", "3")),
+      Map("a" -> ColumnType("4", "5", "6"), "b" -> ColumnType("4", "5", "6")),
+      Map("a" -> ColumnType("7", "8", "9"), "b" -> ColumnType("7", "8", "9"))))
 
-    table.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
-      case Nil => TestActor.KeepRunning
-      case GetColumnFromTable("a") => sender ! ActorsForColumn("a", Seq(columnA0.ref, columnA1.ref, columnA2.ref)); TestActor.KeepRunning
-      case GetColumnFromTable("b") => sender ! ActorsForColumn("b", Seq(columnB0.ref, columnB1.ref, columnB2.ref)); TestActor.KeepRunning
-    })
-
-    columnA0.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
-      case ScanColumn(None) => sender ! ScannedValues(0, "a", ColumnType("1", "2", "3")); TestActor.KeepRunning
-    })
-
-    columnA1.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
-      case ScanColumn(None) => sender ! ScannedValues(1, "a", ColumnType("4", "5", "6")); TestActor.KeepRunning
-    })
-
-    columnA2.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
-      case ScanColumn(None) => sender ! ScannedValues(2, "a", ColumnType("7", "8", "9")); TestActor.KeepRunning
-    })
-
-    columnB0.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
-      case ScanColumn(None) => sender ! ScannedValues(0, "b", ColumnType("1", "2", "3")); TestActor.KeepRunning
-    })
-
-    columnB1.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
-      case ScanColumn(None) => sender ! ScannedValues(1, "b", ColumnType("4", "5", "6")); TestActor.KeepRunning
-    })
-
-    columnB2.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
-      case ScanColumn(None) => sender ! ScannedValues(2, "b", ColumnType("7", "8", "9")); TestActor.KeepRunning
-    })
-
-    val projectionOperator = system.actorOf(ProjectionOperator.props(table.ref, Seq("a", "b")))
+    val projectionOperator = system.actorOf(ProjectionOperator.props(table, Seq("a", "b")))
 
     projectionOperator ! Execute()
     val operatorResult = expectMsgType[QueryResult]

--- a/src/test/scala/de/hpi/svedeb/operators/ScanWorkerTest.scala
+++ b/src/test/scala/de/hpi/svedeb/operators/ScanWorkerTest.scala
@@ -1,63 +1,26 @@
 package de.hpi.svedeb.operators
 
-import akka.actor.ActorRef
-import akka.testkit.{TestActor, TestProbe}
 import de.hpi.svedeb.AbstractActorTest
 import de.hpi.svedeb.operators.workers.ScanWorker
 import de.hpi.svedeb.operators.workers.ScanWorker.{ScanJob, ScanWorkerResult}
-import de.hpi.svedeb.table.Column.{FilterColumn, FilteredRowIndices, ScanColumn, ScannedValues}
 import de.hpi.svedeb.table.ColumnType
-import de.hpi.svedeb.table.Partition.{ColumnsRetrieved, GetColumns}
 import org.scalatest.Matchers._
 
-// TODO: Consider splitting up this test into multiple smaller ones that do not have so many dependencies
 class ScanWorkerTest extends AbstractActorTest("ScanWorker") {
   "A scan worker" should "return scanned partition" in {
-    val column = TestProbe("Column")
-    column.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
-      case ScanColumn(indices) => sender ! ScannedValues(0, "columnA", ColumnType("a", "b")); TestActor.KeepRunning
-      case FilterColumn(predicate) ⇒ sender ! FilteredRowIndices(0, "columnA", Seq(0, 1)); TestActor.KeepRunning
-    })
-
-    val partition = TestProbe("Partition")
-    partition.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
-      case GetColumns() ⇒ sender ! ColumnsRetrieved(Map("columnA" -> column.ref)); TestActor.KeepRunning
-    })
-
-    val scanWorker = system.actorOf(ScanWorker.props(partition.ref, 0, "columnA", _ => true))
+    val partition = generatePartitionTestProbe(0, Map("columnA" -> ColumnType("a", "b")))._1
+    val scanWorker = system.actorOf(ScanWorker.props(partition, 0, "columnA", _ => true))
 
     scanWorker ! ScanJob()
     val workerResult = expectMsgType[ScanWorkerResult]
-    workerResult.partition.get ! GetColumns()
 
-    val columns = expectMsgType[ColumnsRetrieved]
-    columns.columns.foreach{ case (_, columnRef) => columnRef ! ScanColumn()}
-
-    val scannedValues = expectMsgType[ScannedValues]
-    scannedValues.values shouldEqual ColumnType("a", "b")
+    assert(workerResult.partition.isDefined)
+    checkPartition(workerResult.partition.get, Map("columnA" -> ColumnType("a", "b")))
   }
 
   it should "return filtered partition" in {
-    val columnA = TestProbe("ColumnA")
-    columnA.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
-      case ScanColumn(_) => sender ! ScannedValues(0, "columnA", ColumnType("b")); TestActor.KeepRunning
-      case FilterColumn(_) ⇒ sender ! FilteredRowIndices(0, "columnA", Seq(1)); TestActor.KeepRunning
-    })
-
-    val columnB = TestProbe("ColumnB")
-    columnB.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
-      case ScanColumn(_) => sender ! ScannedValues(0, "columnB", ColumnType("d")); TestActor.KeepRunning
-    })
-
-    val partition = TestProbe("Partition")
-    partition.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
-      case GetColumns() ⇒ {
-        val columnMap = Map("columnA" -> columnA.ref, "columnB" -> columnB.ref)
-        sender ! ColumnsRetrieved(columnMap)
-      }; TestActor.KeepRunning
-    })
-
-    val scanWorker = system.actorOf(ScanWorker.props(partition.ref, 0, "columnA", value => value == "b"))
+    val partition = generatePartitionTestProbe(0, Map("columnA" -> ColumnType("b"), "columnB" -> ColumnType("d")))._1
+    val scanWorker = system.actorOf(ScanWorker.props(partition, 0, "columnA", value => value == "b"))
 
     scanWorker ! ScanJob()
     val workerResult = expectMsgType[ScanWorkerResult]

--- a/src/test/scala/de/hpi/svedeb/operators/workers/NestedLoopJoinWorkerTest.scala
+++ b/src/test/scala/de/hpi/svedeb/operators/workers/NestedLoopJoinWorkerTest.scala
@@ -7,20 +7,66 @@ import de.hpi.svedeb.operators.workers.NestedLoopJoinWorker.{JoinJob, PartialRes
 import de.hpi.svedeb.table.Column.{ScanColumn, ScannedValues}
 import de.hpi.svedeb.table.ColumnType
 import de.hpi.svedeb.table.Partition.{ColumnsRetrieved, GetColumns}
+import org.scalatest.Matchers._
 
 class NestedLoopJoinWorkerTest extends AbstractActorTest("NestedLoopJoinWorker") {
 
   "A NestedLoopJoin" should "join two columns" in {
     val leftColumn = TestProbe("LeftColumn")
     leftColumn.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
-      case ScanColumn(None) => sender.tell(ScannedValues(0, "a", ColumnType("a", "b")), leftColumn.ref); TestActor.KeepRunning
-      case ScanColumn(Some(_)) => sender ! ScannedValues(0, "a", ColumnType("b")); TestActor.KeepRunning
+      case ScanColumn(None) => sender.tell(ScannedValues(0, "a", ColumnType("1", "2")), leftColumn.ref); TestActor.KeepRunning
+      case ScanColumn(Some(Seq(1))) => sender ! ScannedValues(0, "a", ColumnType("2")); TestActor.KeepRunning
+    })
+
+    val leftColumn2 = TestProbe("LeftColumn2")
+    leftColumn2.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
+      case ScanColumn(None) => sender.tell(ScannedValues(0, "b", ColumnType("b1", "b2")), leftColumn2.ref); TestActor.KeepRunning
+      case ScanColumn(Some(Seq(1))) => sender ! ScannedValues(0, "b", ColumnType("b2")); TestActor.KeepRunning
     })
 
     val rightColumn = TestProbe("RightColumn")
     rightColumn.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
-      case ScanColumn(None) => sender.tell(ScannedValues(0, "b", ColumnType("b", "c")), rightColumn.ref); TestActor.KeepRunning
-      case ScanColumn(Some(_)) => sender ! ScannedValues(0, "b", ColumnType("b")); TestActor.KeepRunning
+      case ScanColumn(None) => sender.tell(ScannedValues(0, "c", ColumnType("2", "3")), rightColumn.ref); TestActor.KeepRunning
+      case ScanColumn(Some(Seq(0))) => sender ! ScannedValues(0, "c", ColumnType("2")); TestActor.KeepRunning
+    })
+
+    val rightColumn2 = TestProbe("RightColumn2")
+    rightColumn2.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
+      case ScanColumn(None) => sender.tell(ScannedValues(0, "d", ColumnType("d2", "d3")), rightColumn2.ref); TestActor.KeepRunning
+      case ScanColumn(Some(Seq(0))) => sender ! ScannedValues(0, "d", ColumnType("d2")); TestActor.KeepRunning
+    })
+
+    val leftPartition = TestProbe("LeftPartition")
+    leftPartition.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
+      case GetColumns() ⇒ sender.tell(ColumnsRetrieved(Map("a" -> leftColumn.ref, "b" -> leftColumn2.ref)), leftPartition.ref); TestActor.KeepRunning
+    })
+
+    val rightPartition = TestProbe("RightPartition")
+    rightPartition.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
+      case GetColumns() ⇒ sender.tell(ColumnsRetrieved(Map("c" -> rightColumn.ref, "d" -> rightColumn2.ref)), rightPartition.ref); TestActor.KeepRunning
+    })
+
+    val joinWorker = system.actorOf(NestedLoopJoinWorker.props(leftPartition.ref, rightPartition.ref, 0, "a", "c", _ == _))
+
+    joinWorker ! JoinJob()
+    val workerResult = expectMsgType[PartialResult]
+    checkPartition(workerResult.partition.get, Map(
+      "a" -> ColumnType("2"),
+      "b" -> ColumnType("b2"),
+      "c" -> ColumnType("2"),
+      "d" -> ColumnType("d2")
+    ))
+  }
+
+  it should "return None if no matches" in {
+    val leftColumn = TestProbe("LeftColumn")
+    leftColumn.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
+      case ScanColumn(None) => sender.tell(ScannedValues(0, "a", ColumnType("a", "b")), leftColumn.ref); TestActor.KeepRunning
+    })
+
+    val rightColumn = TestProbe("RightColumn")
+    rightColumn.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
+      case ScanColumn(None) => sender.tell(ScannedValues(0, "b", ColumnType("c", "d")), rightColumn.ref); TestActor.KeepRunning
     })
 
     val leftPartition = TestProbe("LeftPartition")
@@ -37,7 +83,6 @@ class NestedLoopJoinWorkerTest extends AbstractActorTest("NestedLoopJoinWorker")
 
     joinWorker ! JoinJob()
     val workerResult = expectMsgType[PartialResult]
-    checkPartition(workerResult.partition.get, Map("a" -> ColumnType("b"), "b" -> ColumnType("b")))
+    workerResult.partition shouldEqual None
   }
-
 }

--- a/src/test/scala/de/hpi/svedeb/operators/workers/NestedLoopJoinWorkerTest.scala
+++ b/src/test/scala/de/hpi/svedeb/operators/workers/NestedLoopJoinWorkerTest.scala
@@ -1,0 +1,43 @@
+package de.hpi.svedeb.operators.workers
+
+import akka.actor.ActorRef
+import akka.testkit.{TestActor, TestProbe}
+import de.hpi.svedeb.AbstractActorTest
+import de.hpi.svedeb.operators.workers.NestedLoopJoinWorker.{JoinJob, PartialResult}
+import de.hpi.svedeb.table.Column.{ScanColumn, ScannedValues}
+import de.hpi.svedeb.table.ColumnType
+import de.hpi.svedeb.table.Partition.{ColumnsRetrieved, GetColumns}
+
+class NestedLoopJoinWorkerTest extends AbstractActorTest("NestedLoopJoinWorker") {
+
+  "A NestedLoopJoin" should "join two columns" in {
+    val leftColumn = TestProbe("LeftColumn")
+    leftColumn.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
+      case ScanColumn(None) => sender.tell(ScannedValues(0, "a", ColumnType("a", "b")), leftColumn.ref); TestActor.KeepRunning
+      case ScanColumn(Some(_)) => sender ! ScannedValues(0, "a", ColumnType("b")); TestActor.KeepRunning
+    })
+
+    val rightColumn = TestProbe("RightColumn")
+    rightColumn.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
+      case ScanColumn(None) => sender.tell(ScannedValues(0, "b", ColumnType("b", "c")), rightColumn.ref); TestActor.KeepRunning
+      case ScanColumn(Some(_)) => sender ! ScannedValues(0, "b", ColumnType("b")); TestActor.KeepRunning
+    })
+
+    val leftPartition = TestProbe("LeftPartition")
+    leftPartition.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
+      case GetColumns() ⇒ sender.tell(ColumnsRetrieved(Map("a" -> leftColumn.ref)), leftPartition.ref); TestActor.KeepRunning
+    })
+
+    val rightPartition = TestProbe("RightPartition")
+    rightPartition.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
+      case GetColumns() ⇒ sender.tell(ColumnsRetrieved(Map("b" -> rightColumn.ref)), rightPartition.ref); TestActor.KeepRunning
+    })
+
+    val joinWorker = system.actorOf(NestedLoopJoinWorker.props(leftPartition.ref, rightPartition.ref, 0, "a", "b", _ == _))
+
+    joinWorker ! JoinJob()
+    val workerResult = expectMsgType[PartialResult]
+    checkPartition(workerResult.partition.get, Map("a" -> ColumnType("b"), "b" -> ColumnType("b")))
+  }
+
+}

--- a/src/test/scala/de/hpi/svedeb/operators/workers/NestedLoopJoinWorkerTest.scala
+++ b/src/test/scala/de/hpi/svedeb/operators/workers/NestedLoopJoinWorkerTest.scala
@@ -1,52 +1,17 @@
 package de.hpi.svedeb.operators.workers
 
-import akka.actor.ActorRef
-import akka.testkit.{TestActor, TestProbe}
 import de.hpi.svedeb.AbstractActorTest
 import de.hpi.svedeb.operators.workers.NestedLoopJoinWorker.{JoinJob, PartialResult}
-import de.hpi.svedeb.table.Column.{ScanColumn, ScannedValues}
 import de.hpi.svedeb.table.ColumnType
-import de.hpi.svedeb.table.Partition.{ColumnsRetrieved, GetColumns}
 import org.scalatest.Matchers._
 
 class NestedLoopJoinWorkerTest extends AbstractActorTest("NestedLoopJoinWorker") {
 
   "A NestedLoopJoin" should "join two columns" in {
-    val leftColumn = TestProbe("LeftColumn")
-    leftColumn.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
-      case ScanColumn(None) => sender.tell(ScannedValues(0, "a", ColumnType("1", "2")), leftColumn.ref); TestActor.KeepRunning
-      case ScanColumn(Some(Seq(1))) => sender ! ScannedValues(0, "a", ColumnType("2")); TestActor.KeepRunning
-    })
+    val leftPartition = generatePartitionTestProbe(0, Map("a" -> ColumnType("1", "2"), "b" -> ColumnType("b1", "b2")))._1
+    val rightPartition = generatePartitionTestProbe(0, Map("c" -> ColumnType("2", "3"), "d" -> ColumnType("d2", "d3")))._1
 
-    val leftColumn2 = TestProbe("LeftColumn2")
-    leftColumn2.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
-      case ScanColumn(None) => sender.tell(ScannedValues(0, "b", ColumnType("b1", "b2")), leftColumn2.ref); TestActor.KeepRunning
-      case ScanColumn(Some(Seq(1))) => sender ! ScannedValues(0, "b", ColumnType("b2")); TestActor.KeepRunning
-    })
-
-    val rightColumn = TestProbe("RightColumn")
-    rightColumn.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
-      case ScanColumn(None) => sender.tell(ScannedValues(0, "c", ColumnType("2", "3")), rightColumn.ref); TestActor.KeepRunning
-      case ScanColumn(Some(Seq(0))) => sender ! ScannedValues(0, "c", ColumnType("2")); TestActor.KeepRunning
-    })
-
-    val rightColumn2 = TestProbe("RightColumn2")
-    rightColumn2.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
-      case ScanColumn(None) => sender.tell(ScannedValues(0, "d", ColumnType("d2", "d3")), rightColumn2.ref); TestActor.KeepRunning
-      case ScanColumn(Some(Seq(0))) => sender ! ScannedValues(0, "d", ColumnType("d2")); TestActor.KeepRunning
-    })
-
-    val leftPartition = TestProbe("LeftPartition")
-    leftPartition.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
-      case GetColumns() ⇒ sender.tell(ColumnsRetrieved(Map("a" -> leftColumn.ref, "b" -> leftColumn2.ref)), leftPartition.ref); TestActor.KeepRunning
-    })
-
-    val rightPartition = TestProbe("RightPartition")
-    rightPartition.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
-      case GetColumns() ⇒ sender.tell(ColumnsRetrieved(Map("c" -> rightColumn.ref, "d" -> rightColumn2.ref)), rightPartition.ref); TestActor.KeepRunning
-    })
-
-    val joinWorker = system.actorOf(NestedLoopJoinWorker.props(leftPartition.ref, rightPartition.ref, 0, "a", "c", _ == _))
+    val joinWorker = system.actorOf(NestedLoopJoinWorker.props(leftPartition, rightPartition, 0, "a", "c", _ == _))
 
     joinWorker ! JoinJob()
     val workerResult = expectMsgType[PartialResult]
@@ -59,27 +24,11 @@ class NestedLoopJoinWorkerTest extends AbstractActorTest("NestedLoopJoinWorker")
   }
 
   it should "return None if no matches" in {
-    val leftColumn = TestProbe("LeftColumn")
-    leftColumn.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
-      case ScanColumn(None) => sender.tell(ScannedValues(0, "a", ColumnType("a", "b")), leftColumn.ref); TestActor.KeepRunning
-    })
 
-    val rightColumn = TestProbe("RightColumn")
-    rightColumn.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
-      case ScanColumn(None) => sender.tell(ScannedValues(0, "b", ColumnType("c", "d")), rightColumn.ref); TestActor.KeepRunning
-    })
+    val leftPartition = generatePartitionTestProbe(0, Map("a" -> ColumnType("a", "b")))._1
+    val rightPartition = generatePartitionTestProbe(0, Map("b" -> ColumnType("c", "d")))._1
 
-    val leftPartition = TestProbe("LeftPartition")
-    leftPartition.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
-      case GetColumns() ⇒ sender.tell(ColumnsRetrieved(Map("a" -> leftColumn.ref)), leftPartition.ref); TestActor.KeepRunning
-    })
-
-    val rightPartition = TestProbe("RightPartition")
-    rightPartition.setAutoPilot((sender: ActorRef, msg: Any) => msg match {
-      case GetColumns() ⇒ sender.tell(ColumnsRetrieved(Map("b" -> rightColumn.ref)), rightPartition.ref); TestActor.KeepRunning
-    })
-
-    val joinWorker = system.actorOf(NestedLoopJoinWorker.props(leftPartition.ref, rightPartition.ref, 0, "a", "b", _ == _))
+    val joinWorker = system.actorOf(NestedLoopJoinWorker.props(leftPartition, rightPartition, 0, "a", "b", _ == _))
 
     joinWorker ! JoinJob()
     val workerResult = expectMsgType[PartialResult]

--- a/src/test/scala/de/hpi/svedeb/operators/workers/ScanWorkerTest.scala
+++ b/src/test/scala/de/hpi/svedeb/operators/workers/ScanWorkerTest.scala
@@ -1,7 +1,6 @@
-package de.hpi.svedeb.operators
+package de.hpi.svedeb.operators.workers
 
 import de.hpi.svedeb.AbstractActorTest
-import de.hpi.svedeb.operators.workers.ScanWorker
 import de.hpi.svedeb.operators.workers.ScanWorker.{ScanJob, ScanWorkerResult}
 import de.hpi.svedeb.table.ColumnType
 import org.scalatest.Matchers._


### PR DESCRIPTION
This PR contains the implementation for the NestedLoopJoin Operator.

Additionally, it simplifies operator tests by providing helper functions to generate TestProbes.